### PR TITLE
feat(Custom Component): optional merge arg in create

### DIFF
--- a/packages/minecraftBedrock/types/customComponent/block.d.ts
+++ b/packages/minecraftBedrock/types/customComponent/block.d.ts
@@ -10,7 +10,7 @@ declare interface TemplateContext {
 	/**
 	 * Modify the block that is using this component
 	 */
-	 create: (template: any, location: string, operation?: (deepMerge: (oldData: any, newData: any) => any, oldData: any, newData: any) => any) => void
+	create: (template: any, location?: string, operation?: (deepMerge: (oldData: any, newData: any) => any, oldData: any, newData: any) => any) => void
 	/**
 	 * Where inside the source file the custom component is located
 	 */

--- a/packages/minecraftBedrock/types/customComponent/block.d.ts
+++ b/packages/minecraftBedrock/types/customComponent/block.d.ts
@@ -10,7 +10,7 @@ declare interface TemplateContext {
 	/**
 	 * Modify the block that is using this component
 	 */
-	create: (template: any, location: string) => void
+	 create: (template: any, location: string, operation?: (deepMerge: (oldData: any, newData: any) => any, oldData: any, newData: any) => any) => void
 	/**
 	 * Where inside the source file the custom component is located
 	 */

--- a/packages/minecraftBedrock/types/customComponent/entity.d.ts
+++ b/packages/minecraftBedrock/types/customComponent/entity.d.ts
@@ -10,7 +10,7 @@ declare interface TemplateContext {
 	/**
 	 * Modify the entity that is using this component
 	 */
-	create: (template: any, location: string, operation?: (deepMerge: (oldData: any, newData: any) => any, oldData: any, newData: any) => any) => void
+	create: (template: any, location?: string, operation?: (deepMerge: (oldData: any, newData: any) => any, oldData: any, newData: any) => any) => void
 	/**
 	 * Add an animation to the entity
 	 */

--- a/packages/minecraftBedrock/types/customComponent/entity.d.ts
+++ b/packages/minecraftBedrock/types/customComponent/entity.d.ts
@@ -10,7 +10,7 @@ declare interface TemplateContext {
 	/**
 	 * Modify the entity that is using this component
 	 */
-	create: (template: any, location: string) => void
+	create: (template: any, location: string, operation?: (deepMerge: (oldData: any, newData: any) => any, oldData: any, newData: any) => any) => void
 	/**
 	 * Add an animation to the entity
 	 */

--- a/packages/minecraftBedrock/types/customComponent/item.d.ts
+++ b/packages/minecraftBedrock/types/customComponent/item.d.ts
@@ -10,7 +10,7 @@ declare interface TemplateContext {
 	/**
 	 * Modify the item that is using this component
 	 */
-	create: (template: any, location: string) => void
+	create: (template: any, location: string, operation?: (deepMerge: (oldData: any, newData: any) => any, oldData: any, newData: any) => any) => void
 	/**
 	 * Where inside the source file the custom component is located
 	 */
@@ -26,7 +26,7 @@ declare interface TemplateContext {
 		/**
 		 * Modify the player entity
 		 */
-		create: (template: any, location: string) => void
+		create: (template: any, location: string, operation?: (deepMerge: (oldData: any, newData: any) => any, oldData: any, newData: any) => any) => void
 		/**
 		 * Add an animation to the player entity
 		 */

--- a/packages/minecraftBedrock/types/customComponent/item.d.ts
+++ b/packages/minecraftBedrock/types/customComponent/item.d.ts
@@ -10,7 +10,7 @@ declare interface TemplateContext {
 	/**
 	 * Modify the item that is using this component
 	 */
-	create: (template: any, location: string, operation?: (deepMerge: (oldData: any, newData: any) => any, oldData: any, newData: any) => any) => void
+	create: (template: any, location?: string, operation?: (deepMerge: (oldData: any, newData: any) => any, oldData: any, newData: any) => any) => void
 	/**
 	 * Where inside the source file the custom component is located
 	 */
@@ -26,7 +26,7 @@ declare interface TemplateContext {
 		/**
 		 * Modify the player entity
 		 */
-		create: (template: any, location: string, operation?: (deepMerge: (oldData: any, newData: any) => any, oldData: any, newData: any) => any) => void
+		create: (template: any, location?: string, operation?: (deepMerge: (oldData: any, newData: any) => any, oldData: any, newData: any) => any) => void
 		/**
 		 * Add an animation to the player entity
 		 */


### PR DESCRIPTION
This is a relatively small feature that introduces the option to override the merge behaviour of the create function in the custom component core extension. The function signature is `(deepMerge: (oldData: any, newData: any) => any, oldData: any, newData: any) => any`. It receives the default `deepMerge` function to, for example, allow normal behaviour to be resumed.
This update also includes typings and documentation which are in their respective pull requests. A minor typing and documentation fix is also included to bring them into agreement with the implementation of the create function.