### PR TITLE
Added "durability" damage option

### DIFF
--- a/packages/minecraftBedrock/schema/general/vanilla/damageType.json
+++ b/packages/minecraftBedrock/schema/general/vanilla/damageType.json
@@ -35,6 +35,7 @@
 		"temperature",
 		"all",
 		"stalactite",
-		"stalagmite"
+		"stalagmite",
+		"durability"
 	]
 }


### PR DESCRIPTION
Been missing for a while. :)

Used for taking away durability when used in a damage event inside of a 1.16.100+ item.