### PR TITLE
Update armor preset

### DIFF
--- a/packages/minecraftBedrock/preset/item/armor/attachableBoots.json
+++ b/packages/minecraftBedrock/preset/item/armor/attachableBoots.json
@@ -1,24 +1,25 @@
 {
-    "format_version": "1.8.0",
-    "minecraft:attachable": {
-      "description": {
-        "identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_boots",
-        "materials": {
-          "default": "armor",
-          "enchanted": "armor_enchanted"
-        },
-        "textures": {
-          "default": "textures/models/armor/{{IDENTIFIER}}_1",
-          "enchanted": "textures/misc/enchanted_item_glint"
-        },
-        "geometry": {
-          "default": "geometry.humanoid.armor.boots"
-        },
-        "scripts": {
-          "parent_setup": "variable.boot_layer_visible = 0.0;"
-        },
-        "render_controllers": [ "controller.render.armor" ]
-      }
-    }
-  }
-  
+	"format_version": "1.8.0",
+	"minecraft:attachable": {
+		"description": {
+			"identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_boots",
+			"materials": {
+				"default": "armor",
+				"enchanted": "armor_enchanted"
+			},
+			"textures": {
+				"default": "textures/models/armor/{{IDENTIFIER}}_1",
+				"enchanted": "textures/misc/enchanted_item_glint"
+			},
+			"geometry": {
+				"default": "geometry.humanoid.armor.boots"
+			},
+			"scripts": {
+				"parent_setup": "variable.boot_layer_visible = 0.0;"
+			},
+			"render_controllers": [
+				"controller.render.armor"
+			]
+		}
+	}
+}

--- a/packages/minecraftBedrock/preset/item/armor/attachableChestplate.json
+++ b/packages/minecraftBedrock/preset/item/armor/attachableChestplate.json
@@ -1,24 +1,25 @@
 {
-    "format_version": "1.8.0",
-    "minecraft:attachable": {
-      "description": {
-        "identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_chestplate",
-        "materials": {
-          "default": "armor",
-          "enchanted": "armor_enchanted"
-        },
-        "textures": {
-          "default": "textures/models/armor/{{IDENTIFIER}}_1",
-          "enchanted": "textures/misc/enchanted_item_glint"
-        },
-        "geometry": {
-          "default": "geometry.humanoid.armor.chestplate"
-        },
-        "scripts": {
-          "parent_setup": "variable.helmet_layer_visible = 0.0;"
-        },
-        "render_controllers": [ "controller.render.armor" ]
-      }
-    }
-  }
-  
+	"format_version": "1.8.0",
+	"minecraft:attachable": {
+		"description": {
+			"identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_chestplate",
+			"materials": {
+				"default": "armor",
+				"enchanted": "armor_enchanted"
+			},
+			"textures": {
+				"default": "textures/models/armor/{{IDENTIFIER}}_1",
+				"enchanted": "textures/misc/enchanted_item_glint"
+			},
+			"geometry": {
+				"default": "geometry.humanoid.armor.chestplate"
+			},
+			"scripts": {
+				"parent_setup": "variable.chest_layer_visible = 0.0;"
+			},
+			"render_controllers": [
+				"controller.render.armor"
+			]
+		}
+	}
+}

--- a/packages/minecraftBedrock/preset/item/armor/attachableHelmet.json
+++ b/packages/minecraftBedrock/preset/item/armor/attachableHelmet.json
@@ -1,24 +1,25 @@
 {
-    "format_version": "1.8.0",
-    "minecraft:attachable": {
-      "description": {
-        "identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_helmet",
-        "materials": {
-          "default": "armor",
-          "enchanted": "armor_enchanted"
-        },
-        "textures": {
-          "default": "textures/models/armor/{{IDENTIFIER}}_1",
-          "enchanted": "textures/misc/enchanted_item_glint"
-        },
-        "geometry": {
-          "default": "geometry.humanoid.armor.helmet"
-        },
-        "scripts": {
-          "parent_setup": "variable.helmet_layer_visible = 0.0;"
-        },
-        "render_controllers": [ "controller.render.armor" ]
-      }
-    }
-  }
-  
+	"format_version": "1.8.0",
+	"minecraft:attachable": {
+		"description": {
+			"identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_helmet",
+			"materials": {
+				"default": "armor",
+				"enchanted": "armor_enchanted"
+			},
+			"textures": {
+				"default": "textures/models/armor/{{IDENTIFIER}}_1",
+				"enchanted": "textures/misc/enchanted_item_glint"
+			},
+			"geometry": {
+				"default": "geometry.humanoid.armor.helmet"
+			},
+			"scripts": {
+				"parent_setup": "variable.helmet_layer_visible = 0.0;"
+			},
+			"render_controllers": [
+				"controller.render.armor"
+			]
+		}
+	}
+}

--- a/packages/minecraftBedrock/preset/item/armor/attachableLeggings.json
+++ b/packages/minecraftBedrock/preset/item/armor/attachableLeggings.json
@@ -1,24 +1,25 @@
 {
-    "format_version": "1.8.0",
-    "minecraft:attachable": {
-      "description": {
-        "identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_leggings",
-        "materials": {
-          "default": "armor",
-          "enchanted": "armor_enchanted"
-        },
-        "textures": {
-          "default": "textures/models/armor/{{IDENTIFIER}}_2",
-          "enchanted": "textures/misc/enchanted_item_glint"
-        },
-        "geometry": {
-          "default": "geometry.humanoid.armor.leggings"
-        },
-        "scripts": {
-          "parent_setup": "variable.leg_layer_visible = 0.0;"
-        },
-        "render_controllers": [ "controller.render.armor" ]
-      }
-    }
-  }
-  
+	"format_version": "1.8.0",
+	"minecraft:attachable": {
+		"description": {
+			"identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_leggings",
+			"materials": {
+				"default": "armor",
+				"enchanted": "armor_enchanted"
+			},
+			"textures": {
+				"default": "textures/models/armor/{{IDENTIFIER}}_2",
+				"enchanted": "textures/misc/enchanted_item_glint"
+			},
+			"geometry": {
+				"default": "geometry.humanoid.armor.leggings"
+			},
+			"scripts": {
+				"parent_setup": "variable.leg_layer_visible = 0.0;"
+			},
+			"render_controllers": [
+				"controller.render.armor"
+			]
+		}
+	}
+}

--- a/packages/minecraftBedrock/preset/item/armor/itemBoots.json
+++ b/packages/minecraftBedrock/preset/item/armor/itemBoots.json
@@ -1,33 +1,52 @@
 {
-    "format_version": "1.16.100",
-    "minecraft:item": {
-      "description": {
-        "identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_boots",
-		    "category": "equipment"
-      },
-      "components": {
-        "minecraft:max_stack_size": 1, 
-        "minecraft:enchantable": {     
-          "value": 9,		    
-          "slot": "armor_feet"	 
-        },
-        "minecraft:durability": {		
-          "max_durability": 195,		
-          "damage_chance": {		
-            "min": 60,			
-            "max": 100
-          }
-        },
-        "minecraft:icon": {	
-          "texture": "{{PROJECT_PREFIX}}_{{IDENTIFIER}}_boots"
-        },
-        "minecraft:render_offsets": "boots",
-        "minecraft:armor": {		
-          "protection": 2		
-        },
-        "minecraft:wearable": {		
-          "slot": "slot.armor.feet"	
-        }
-      }
-    }
-  }
+	"format_version": "1.16.100",
+	"minecraft:item": {
+		"description": {
+			"identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_boots",
+			"category": "equipment"
+		},
+		"components": {
+			"minecraft:max_stack_size": 1,
+			"minecraft:enchantable": {
+				"value": 9,
+				"slot": "armor_feet"
+			},
+			"minecraft:durability": {
+				"max_durability": 195,
+				"damage_chance": {
+					"min": 60,
+					"max": 100
+				}
+			},
+			"minecraft:icon": {
+				"texture": "{{PROJECT_PREFIX}}_{{IDENTIFIER}}_boots"
+			},
+			"minecraft:render_offsets": "boots",
+			"minecraft:armor": {
+				"protection": 2
+			},
+			"minecraft:wearable": {
+				"slot": "slot.armor.feet"
+			},
+			"minecraft:creative_category": {
+				"parent": "itemGroup.name.boots"
+			},
+			"minecraft:repairable": {
+				"repair_items": [
+					{
+						"items": [
+							"minecraft:iron_ingot"
+						],
+						"repair_amount": "query.max_durability * 0.25"
+					},
+					{
+						"items": [
+							"{{PROJECT_PREFIX}}:{{IDENTIFIER}}_boots"
+						],
+						"repair_amount": "context.other->query.remaining_durability + 0.12 * context.other->query.max_durability"
+					}
+				]
+			}
+		}
+	}
+}

--- a/packages/minecraftBedrock/preset/item/armor/itemChestplate.json
+++ b/packages/minecraftBedrock/preset/item/armor/itemChestplate.json
@@ -1,33 +1,52 @@
 {
-    "format_version": "1.16.100",
-    "minecraft:item": {
-      "description": {
-        "identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_chestplate",
-		"category": "equipment"
-      },
-      "components": {
-        "minecraft:max_stack_size": 1, 
-        "minecraft:enchantable": {     
-          "value": 9,		    
-          "slot": "armor_torso"	 
-        },
-        "minecraft:durability": {		
-          "max_durability": 240,		
-          "damage_chance": {		
-            "min": 60,			
-            "max": 100
-          }
-        },
-        "minecraft:icon": {	
-          "texture": "{{PROJECT_PREFIX}}_{{IDENTIFIER}}_chestplate"
-        },
-        "minecraft:render_offsets": "chestplates",	
-        "minecraft:armor": {		
-          "protection": 6
-        },
-        "minecraft:wearable": {		
-          "slot": "slot.armor.chest"	
-        }
-      }
-    }
-  }
+	"format_version": "1.16.100",
+	"minecraft:item": {
+		"description": {
+			"identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_chestplate",
+			"category": "equipment"
+		},
+		"components": {
+			"minecraft:max_stack_size": 1,
+			"minecraft:enchantable": {
+				"value": 9,
+				"slot": "armor_torso"
+			},
+			"minecraft:durability": {
+				"max_durability": 240,
+				"damage_chance": {
+					"min": 60,
+					"max": 100
+				}
+			},
+			"minecraft:icon": {
+				"texture": "{{PROJECT_PREFIX}}_{{IDENTIFIER}}_chestplate"
+			},
+			"minecraft:render_offsets": "chestplates",
+			"minecraft:armor": {
+				"protection": 6
+			},
+			"minecraft:wearable": {
+				"slot": "slot.armor.chest"
+			},
+			"minecraft:creative_category": {
+				"parent": "itemGroup.name.chestplate"
+			},
+			"minecraft:repairable": {
+				"repair_items": [
+					{
+						"items": [
+							"minecraft:iron_ingot"
+						],
+						"repair_amount": "query.max_durability * 0.25"
+					},
+					{
+						"items": [
+							"{{PROJECT_PREFIX}}:{{IDENTIFIER}}_chestplate"
+						],
+						"repair_amount": "context.other->query.remaining_durability + 0.12 * context.other->query.max_durability"
+					}
+				]
+			}
+		}
+	}
+}

--- a/packages/minecraftBedrock/preset/item/armor/itemHelmet.json
+++ b/packages/minecraftBedrock/preset/item/armor/itemHelmet.json
@@ -1,33 +1,52 @@
 {
-    "format_version": "1.16.100",
-    "minecraft:item": {
-      "description": {
-        "identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_helmet",
-		    "category": "equipment"
-      },
-      "components": {
-        "minecraft:max_stack_size": 1, 
-        "minecraft:enchantable": {     
-          "value": 9,		    
-          "slot": "armor_head"	 
-        },
-        "minecraft:durability": {		
-          "max_durability": 170,		
-          "damage_chance": {		
-            "min": 60,			
-            "max": 100
-          }
-        },
-        "minecraft:icon": {	
-          "texture": "{{PROJECT_PREFIX}}_{{IDENTIFIER}}_helmet"
-        },
-        "minecraft:render_offsets": "helmets",	
-        "minecraft:armor": {		
-          "protection": 2		
-        },
-        "minecraft:wearable": {		
-          "slot": "slot.armor.head"	
-        }
-      }
-    }
-  }
+	"format_version": "1.16.100",
+	"minecraft:item": {
+		"description": {
+			"identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_helmet",
+			"category": "equipment"
+		},
+		"components": {
+			"minecraft:max_stack_size": 1,
+			"minecraft:enchantable": {
+				"value": 9,
+				"slot": "armor_head"
+			},
+			"minecraft:durability": {
+				"max_durability": 165,
+				"damage_chance": {
+					"min": 60,
+					"max": 100
+				}
+			},
+			"minecraft:icon": {
+				"texture": "{{PROJECT_PREFIX}}_{{IDENTIFIER}}_helmet"
+			},
+			"minecraft:render_offsets": "helmets",
+			"minecraft:armor": {
+				"protection": 2
+			},
+			"minecraft:wearable": {
+				"slot": "slot.armor.head"
+			},
+			"minecraft:creative_category": {
+				"parent": "itemGroup.name.helmet"
+			},
+			"minecraft:repairable": {
+				"repair_items": [
+					{
+						"items": [
+							"minecraft:iron_ingot"
+						],
+						"repair_amount": "query.max_durability * 0.25"
+					},
+					{
+						"items": [
+							"{{PROJECT_PREFIX}}:{{IDENTIFIER}}_helmet"
+						],
+						"repair_amount": "context.other->query.remaining_durability + 0.12 * context.other->query.max_durability"
+					}
+				]
+			}
+		}
+	}
+}

--- a/packages/minecraftBedrock/preset/item/armor/itemLeggings.json
+++ b/packages/minecraftBedrock/preset/item/armor/itemLeggings.json
@@ -1,33 +1,52 @@
 {
-    "format_version": "1.16.100",
-    "minecraft:item": {
-      "description": {
-        "identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_leggings",
-		    "category": "equipment"
-      },
-      "components": {
-        "minecraft:max_stack_size": 1, 
-        "minecraft:enchantable": {     
-          "value": 9,		    
-          "slot": "armor_legs"	 
-        },
-        "minecraft:durability": {		
-          "max_durability": 125,		
-          "damage_chance": {		
-            "min": 60,			
-            "max": 100
-          }
-        },
-        "minecraft:icon": {	
-          "texture": "{{PROJECT_PREFIX}}_{{IDENTIFIER}}_leggings"
-        },
-        "minecraft:render_offsets": "leggings",	
-        "minecraft:armor": {		
-          "protection": 5		
-        },
-        "minecraft:wearable": {		
-          "slot": "slot.armor.legs"	
-        }
-      }
-    }
-  }
+	"format_version": "1.16.100",
+	"minecraft:item": {
+		"description": {
+			"identifier": "{{PROJECT_PREFIX}}:{{IDENTIFIER}}_leggings",
+			"category": "equipment"
+		},
+		"components": {
+			"minecraft:max_stack_size": 1,
+			"minecraft:enchantable": {
+				"value": 9,
+				"slot": "armor_legs"
+			},
+			"minecraft:durability": {
+				"max_durability": 225,
+				"damage_chance": {
+					"min": 60,
+					"max": 100
+				}
+			},
+			"minecraft:icon": {
+				"texture": "{{PROJECT_PREFIX}}_{{IDENTIFIER}}_leggings"
+			},
+			"minecraft:render_offsets": "leggings",
+			"minecraft:armor": {
+				"protection": 5
+			},
+			"minecraft:wearable": {
+				"slot": "slot.armor.legs"
+			},
+			"minecraft:creative_category": {
+				"parent": "itemGroup.name.leggings"
+			},
+			"minecraft:repairable": {
+				"repair_items": [
+					{
+						"items": [
+							"minecraft:iron_ingot"
+						],
+						"repair_amount": "query.max_durability * 0.25"
+					},
+					{
+						"items": [
+							"{{PROJECT_PREFIX}}:{{IDENTIFIER}}_leggings"
+						],
+						"repair_amount": "context.other->query.remaining_durability + 0.12 * context.other->query.max_durability"
+					}
+				]
+			}
+		}
+	}
+}

--- a/packages/minecraftBedrock/preset/item/armor/itemTexture.json
+++ b/packages/minecraftBedrock/preset/item/armor/itemTexture.json
@@ -1,20 +1,16 @@
 {
 	"texture_data": {
 		"{{PROJECT_PREFIX}}_{{IDENTIFIER}}_helmet": {
-			"textures": ["textures/items/{{PRESET_PATH}}{{IDENTIFIER}}_helmet"]
+			"textures": "textures/items/{{PRESET_PATH}}{{IDENTIFIER}}_helmet"
 		},
 		"{{PROJECT_PREFIX}}_{{IDENTIFIER}}_chestplate": {
-			"textures": [
-				"textures/items/{{PRESET_PATH}}{{IDENTIFIER}}_chestplate"
-			]
+			"textures": "textures/items/{{PRESET_PATH}}{{IDENTIFIER}}_chestplate"
 		},
 		"{{PROJECT_PREFIX}}_{{IDENTIFIER}}_leggings": {
-			"textures": [
-				"textures/items/{{PRESET_PATH}}{{IDENTIFIER}}_leggings"
-			]
+			"textures": "textures/items/{{PRESET_PATH}}{{IDENTIFIER}}_leggings"
 		},
 		"{{PROJECT_PREFIX}}_{{IDENTIFIER}}_boots": {
-			"textures": ["textures/items/{{PRESET_PATH}}{{IDENTIFIER}}_boots"]
+			"textures": "textures/items/{{PRESET_PATH}}{{IDENTIFIER}}_boots"
 		}
 	}
 }

--- a/packages/minecraftBedrock/preset/item/armor/manifest.json
+++ b/packages/minecraftBedrock/preset/item/armor/manifest.json
@@ -4,23 +4,45 @@
 	"description": "Creates a new armor set.",
 	"category": "fileType.item",
 	"requires": {
-		"targetVersion": [">=", "1.16.100"],
-		"packTypes": ["behaviorPack", "resourcePack"],
-		"experimentalGameplay": ["holidayCreatorFeatures"]
+		"targetVersion": [
+			">=",
+			"1.16.100"
+		],
+		"packTypes": [
+			"behaviorPack",
+			"resourcePack"
+		],
+		"experimentalGameplay": [
+			"holidayCreatorFeatures"
+		]
 	},
 	"additionalModels": {
 		"PRESET_PATH": ""
 	},
 	"fields": [
 		[
-			"Identifier",
+			"Identifier (e.g. \"iron\")",
 			"IDENTIFIER",
-			{ "validate": ["required", "alphanumeric", "lowercase"] }
+			{
+				"validate": [
+					"required",
+					"alphanumeric",
+					"lowercase"
+				]
+			}
 		],
-		["Display Name", "IDENTIFIER_NAME", { "validate": ["required"] }],
+		[
+			"Display Name (e.g. \"Iron\")",
+			"IDENTIFIER_NAME",
+			{
+				"validate": [
+					"required"
+				]
+			}
+		],
 		[
 			"Helmet",
-			"HELMET", 
+			"HELMET",
 			{
 				"type": "switch",
 				"default": true,
@@ -29,7 +51,7 @@
 		],
 		[
 			"Chestplate",
-			"CHESTPLATE", 
+			"CHESTPLATE",
 			{
 				"type": "switch",
 				"default": true,
@@ -38,7 +60,7 @@
 		],
 		[
 			"Leggings",
-			"LEGGINGS", 
+			"LEGGINGS",
 			{
 				"type": "switch",
 				"default": true,
@@ -47,7 +69,7 @@
 		],
 		[
 			"Boots",
-			"BOOTS", 
+			"BOOTS",
 			{
 				"type": "switch",
 				"default": true,
@@ -55,30 +77,55 @@
 			}
 		]
 	],
-
 	"createFiles": [
 		"./armorSelection.js",
 		[
 			"armor1.png",
 			"textures/models/armor/{{PRESET_PATH}}{{IDENTIFIER}}_1.png",
-			{ "inject": ["IDENTIFIER", "PRESET_PATH"], "packPath": "resourcePack" }
+			{
+				"inject": [
+					"IDENTIFIER",
+					"PRESET_PATH"
+				],
+				"packPath": "resourcePack"
+			}
 		],
 		[
 			"armor2.png",
 			"textures/models/armor/{{PRESET_PATH}}{{IDENTIFIER}}_2.png",
-			{ "inject": ["IDENTIFIER", "PRESET_PATH"], "packPath": "resourcePack" }
+			{
+				"inject": [
+					"IDENTIFIER",
+					"PRESET_PATH"
+				],
+				"packPath": "resourcePack"
+			}
 		]
 	],
 	"expandFiles": [
 		[
 			"itemTexture.json",
 			"textures/item_texture.json",
-			{ "inject": ["IDENTIFIER", "PROJECT_PREFIX", "PRESET_PATH"], "packPath": "resourcePack" }
+			{
+				"inject": [
+					"IDENTIFIER",
+					"PROJECT_PREFIX",
+					"PRESET_PATH"
+				],
+				"packPath": "resourcePack"
+			}
 		],
 		[
 			"en_US.lang",
 			"texts/en_US.lang",
-			{ "inject": ["IDENTIFIER", "IDENTIFIER_NAME", "PROJECT_PREFIX"], "packPath": "resourcePack" }
+			{
+				"inject": [
+					"IDENTIFIER",
+					"IDENTIFIER_NAME",
+					"PROJECT_PREFIX"
+				],
+				"packPath": "resourcePack"
+			}
 		]
 	]
 }


### PR DESCRIPTION
- Add file creation input examples
- Add `minecraft:creative_category`
- Add `minecraft:repairable`
- Fix `item_texture.json`
- Fix chestplate attachable
- Change helmet and leggings durability values to match that of iron armor