### PR TITLE
minecraft:snap_to_surface 1.18 updates

### DIFF
--- a/packages/minecraftBedrock/schema/feature/v1.18.0/features/_main.json
+++ b/packages/minecraftBedrock/schema/feature/v1.18.0/features/_main.json
@@ -50,7 +50,7 @@
             "$ref": "../../v1.16.220/features/growing_plant_feature.json"
         },
         "minecraft:snap_to_surface_feature": {
-            "$ref": "../../v1.16.220/features/snap_to_surface_feature.json"
+            "$ref": "./snap_to_surface_feature.json"
         },
         "minecraft:aggregate_feature": {
             "$ref": "../../v1.16.0/features/aggregate_feature.json"

--- a/packages/minecraftBedrock/schema/feature/v1.18.0/features/_main.json
+++ b/packages/minecraftBedrock/schema/feature/v1.18.0/features/_main.json
@@ -19,6 +19,9 @@
         "minecraft:underwater_cave_carver_feature": {
             "$ref": "./underwater_cave_carver_feature.json"
         },
+        "minecraft:snap_to_surface_feature": {
+            "$ref": "./snap_to_surface_feature.json"
+        },
         "minecraft:catalyst_feature": {
             "$ref": "../../v1.17.30/features/catalyst_feature.json"
         },
@@ -48,9 +51,6 @@
         },
         "minecraft:growing_plant_feature": {
             "$ref": "../../v1.16.220/features/growing_plant_feature.json"
-        },
-        "minecraft:snap_to_surface_feature": {
-            "$ref": "./snap_to_surface_feature.json"
         },
         "minecraft:aggregate_feature": {
             "$ref": "../../v1.16.0/features/aggregate_feature.json"

--- a/packages/minecraftBedrock/schema/feature/v1.18.0/features/snap_to_surface_feature.json
+++ b/packages/minecraftBedrock/schema/feature/v1.18.0/features/snap_to_surface_feature.json
@@ -1,0 +1,37 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"description": "Snaps the y-value of a feature placement pos to the floor or the ceiling within the provided 'vertical_search_range'. The placement biome is preserved. If the snap position goes outside of the placement biome, placement will fail.",
+	"additionalProperties": false,
+	"properties": {
+		"description": {
+			"additionalProperties": false,
+			"properties": {
+				"identifier": {
+					// Needs to strictly match file name - don't change reference to "general/reference..." schema
+					"$ref": "../../../project/prefixedFileIdentifierEnum.json"
+				}
+			}
+		},
+		"feature_to_snap": {
+			"description": "Named reference of feature to be snapped.",
+			"$ref": "../../dynamic/identifierEnum.json"
+		},
+		"vertical_search_range": {
+			"description": "Range to search for a floor or ceiling for snaping the feature.",
+			"type": "integer"
+		},
+		"surface": {
+			"description": "Defines the surface that the y-value of the placement position will be snapped to.",
+			"type": "string",
+			"enum": ["ceiling", "floor", "random_horizontal"]
+		},
+		"allow_air_placement": {
+			"description": "Determines whether the feature can snap through air blocks. Defaults to true.",
+			"type": "boolean"
+		},
+		"allow_underwater_placement": {
+			"description": "Determines whether the feature can snap through water blocks. Defaults to false.",
+			"type": "boolean"
+		}
+	}
+}

--- a/packages/minecraftBedrock/schema/feature/v1.18.10/features/_main.json
+++ b/packages/minecraftBedrock/schema/feature/v1.18.10/features/_main.json
@@ -22,6 +22,9 @@
         "minecraft:underwater_cave_carver_feature": {
             "$ref": "../../v1.18.0/features/underwater_cave_carver_feature.json"
         },
+        "minecraft:snap_to_surface_feature": {
+            "$ref": "../../v1.18.0/features/snap_to_surface_feature.json"
+        },
         "minecraft:catalyst_feature": {
             "$ref": "../../v1.17.30/features/catalyst_feature.json"
         },
@@ -51,9 +54,6 @@
         },
         "minecraft:growing_plant_feature": {
             "$ref": "../../v1.16.220/features/growing_plant_feature.json"
-        },
-        "minecraft:snap_to_surface_feature": {
-            "$ref": "../../v1.16.220/features/snap_to_surface_feature.json"
         },
         "minecraft:aggregate_feature": {
             "$ref": "../../v1.16.0/features/aggregate_feature.json"


### PR DESCRIPTION
- Added in **"allow_air_placement"** and **"allow_underwater_placement"** booleans
- Added in **"random_horizontal"** under the "surface" property