### PR TITLE
Updates Geode Feature & 1.18.0 Ore Feature

### DIFF
--- a/packages/minecraftBedrock/schema/feature/v1.17.0/features/geode_feature.json
+++ b/packages/minecraftBedrock/schema/feature/v1.17.0/features/geode_feature.json
@@ -103,7 +103,7 @@
 			"description": "The likelihood that a special block will be placed on the inside of the geode.",
 			"type": "number"
 		},
-		"use_alternative_layer0_chance": {
+		"use_alternate_layer0_chance": {
 			"description": "The likelihood that a block in the innermost layer of the geode will be replaced with an alternate option.",
 			"type": "number"
 		},

--- a/packages/minecraftBedrock/schema/feature/v1.18.0/features/ore_feature.json
+++ b/packages/minecraftBedrock/schema/feature/v1.18.0/features/ore_feature.json
@@ -21,14 +21,6 @@
 			"description": "Chance of discarding placement if neighboring block is air.",
 			"type": "number"
 		},
-		"may_replace": {
-			"doNotSuggest": true,
-			"deprecationMessage": "Deprecated in favor of 'replace_rules' (format_version: v1.16.220)."
-		},
-		"places_block": {
-			"doNotSuggest": true,
-			"deprecationMessage": "Deprecated in favor of 'replace_rules' (format_version: v1.16.220)."
-		},
 		"replace_rules": {
 			"description": "Collection of replace rules that will be checked in order of definition. If a rule is resolved, the rest will not be resolved for that block position.",
 			"type": "array",

--- a/packages/minecraftBedrock/schema/feature/v1.18.0/features/ore_feature.json
+++ b/packages/minecraftBedrock/schema/feature/v1.18.0/features/ore_feature.json
@@ -21,6 +21,14 @@
 			"description": "Chance of discarding placement if neighboring block is air.",
 			"type": "number"
 		},
+		"may_replace": {
+			"doNotSuggest": true,
+			"deprecationMessage": "Deprecated in favor of 'replace_rules' (format_version: v1.16.220)."
+		},
+		"places_block": {
+			"doNotSuggest": true,
+			"deprecationMessage": "Deprecated in favor of 'replace_rules' (format_version: v1.16.220)."
+		},
 		"replace_rules": {
 			"description": "Collection of replace rules that will be checked in order of definition. If a rule is resolved, the rest will not be resolved for that block position.",
 			"type": "array",


### PR DESCRIPTION
Geode Feature had a typo which I fixed 

For 1.18.0 ore feature I removed may replace and places block. I know it has the do not suggest tag but the thing is it still suggests it in bridge auto complications 
