### PR TITLE
upd: preview 1.20.10.23

### DIFF
--- a/packages/minecraftBedrock/schema/item/main.json
+++ b/packages/minecraftBedrock/schema/item/main.json
@@ -115,7 +115,9 @@
 							"1.19.40",
 							"1.19.50",
 							"1.19.60",
-							"1.19.70"
+							"1.19.70",
+							"1.19.80",
+							"1.20.0"
 						]
 					}
 				}
@@ -124,6 +126,26 @@
 				"$ref": "../project/experimentalGameplay/holidayCreatorFeatures.json",
 				"then": {
 					"$ref": "/data/packages/minecraftBedrock/schema/item/v1.19.0/main.json"
+				},
+				"else": {
+					"$ref": "/data/packages/minecraftBedrock/schema/item/v1.10.0/main.json"
+				}
+			}
+		},
+		{
+			"if": {
+				"properties": {
+					"format_version": {
+						"enum": [
+							"1.20.10"
+						]
+					}
+				}
+			},
+			"then": {
+				"$ref": "../project/experimentalGameplay/holidayCreatorFeatures.json",
+				"then": {
+					"$ref": "/data/packages/minecraftBedrock/schema/item/v1.20.10/main.json"
 				},
 				"else": {
 					"$ref": "/data/packages/minecraftBedrock/schema/item/v1.10.0/main.json"

--- a/packages/minecraftBedrock/schema/item/v1.20.10/components/_main.json
+++ b/packages/minecraftBedrock/schema/item/v1.20.10/components/_main.json
@@ -1,0 +1,138 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"type": "object",
+	"properties": {
+		"minecraft:record": {
+			"$ref": "../../v1.19.0/components/record.json"
+		},
+		"minecraft:chargeable": {
+			"$ref": "../../v1.19.0/components/chargeable.json"
+		},
+		"minecraft:item_storage": {
+			"$ref": "../../v1.18.10/components/item_storage.json"
+		},
+		"minecraft:food": {
+			"$ref": "../../v1.18.10/components/food.json"
+		},
+		"minecraft:creative_category": {
+			"$ref": "../../v1.17.20/components/creative_category.json"
+		},
+		"minecraft:can_destroy_in_creative": {
+			"$ref": "../../v1.16.100/components/can_destroy_in_creative.json"
+		},
+		"minecraft:ignores_permission": {
+			"$ref": "../../v1.16.100/components/ignores_permission.json"
+		},
+		"minecraft:mining_speed": {
+			"$ref": "../../v1.16.100/components/mining_speed.json"
+		},
+		"minecraft:damage": {
+			"$ref": "../../v1.16.100/components/damage.json"
+		},
+		"minecraft:dye_powder": {
+			"$ref": "../../v1.16.100/components/dye_powder.json"
+		},
+		"minecraft:mirrored_art": {
+			"$ref": "../../v1.16.100/components/mirrored_art.json"
+		},
+		"minecraft:explodable": {
+			"$ref": "../../v1.16.100/components/explodable.json"
+		},
+		"minecraft:liquid_clipped": {
+			"$ref": "../../v1.16.100/components/liquid_clipped.json"
+		},
+		"minecraft:allow_off_hand": {
+			"$ref": "../../v1.16.100/components/allow_off_hand.json"
+		},
+		"minecraft:projectile": {
+			"$ref": "../../v1.16.100/components/projectile.json"
+		},
+		"minecraft:block_placer": {
+			"$ref": "../../v1.16.100/components/block_placer.json"
+		},
+		"minecraft:entity_placer": {
+			"$ref": "../../v1.16.100/components/entity_placer.json"
+		},
+		"minecraft:knockback_resistance": {
+			"$ref": "../../v1.16.100/components/knockback_resistance.json"
+		},
+		"minecraft:enchantable": {
+			"$ref": "../../v1.16.100/components/enchantable.json"
+		},
+		"minecraft:shooter": {
+			"$ref": "../../v1.16.100/components/shooter.json"
+		},
+		"minecraft:durability": {
+			"$ref": "../../v1.16.100/components/durability.json"
+		},
+		"minecraft:armor": {
+			"$ref": "../../v1.16.100/components/armor.json"
+		},
+		"minecraft:wearable": {
+			"$ref": "../../v1.16.100/components/wearable.json"
+		},
+		"minecraft:weapon": {
+			"$ref": "../../v1.16.100/components/weapon.json"
+		},
+		"minecraft:repairable": {
+			"$ref": "../../v1.16.100/components/repairable.json"
+		},
+		"minecraft:cooldown": {
+			"$ref": "../../v1.16.100/components/cooldown.json"
+		},
+		"minecraft:on_use_on": {
+			"$ref": "../../v1.16.100/components/on_use_on.json"
+		},
+		"minecraft:on_use": {
+			"$ref": "../../v1.16.100/components/on_use.json"
+		},
+		"minecraft:digger": {
+			"$ref": "../../v1.16.100/components/digger.json"
+		},
+		"minecraft:fertilizer": {
+			"$ref": "../../v1.16.100/components/fertilizer.json"
+		},
+		"minecraft:fuel": {
+			"$ref": "../../v1.16.100/components/fuel.json"
+		},
+		"minecraft:throwable": {
+			"$ref": "../../v1.16.100/components/throwable.json"
+		},
+		"minecraft:potion": {
+			"$ref": "../../v1.16.100/components/potion.json"
+		},
+		"minecraft:icon": {
+			"$ref": "../../v1.16.100/components/icon.json"
+		},
+		"minecraft:use_animation": {
+			"$ref": "../../v1.16.100/components/use_animation.json"
+		},
+		"minecraft:render_offsets": {
+			"$ref": "../../v1.20.10/components/render_offsets.json"
+		},
+		"minecraft:hover_text_color": {
+			"$ref": "../../v1.16.100/components/hover_text_color.json"
+		},
+		"minecraft:display_name": {
+			"$ref": "../../v1.16.100/components/display_name.json"
+		},
+		"minecraft:use_duration": {
+			"$ref": "../../v1.10.0/components/use_duration.json"
+		},
+		"minecraft:max_stack_size": {
+			"$ref": "../../v1.10.0/components/max_stack_size.json"
+		},
+		"minecraft:max_damage": {
+			"$ref": "../../v1.10.0/components/max_damage.json"
+		},
+		"minecraft:hand_equipped": {
+			"$ref": "../../v1.10.0/components/hand_equipped.json"
+		},
+		"minecraft:stacked_by_data": {
+			"$ref": "../../v1.10.0/components/stacked_by_data.json"
+		},
+		"minecraft:foil": {
+			"$ref": "../../v1.10.0/components/foil.json"
+		}
+	}
+}

--- a/packages/minecraftBedrock/schema/item/v1.20.10/components/render_offsets.json
+++ b/packages/minecraftBedrock/schema/item/v1.20.10/components/render_offsets.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "Render Offsets",
+    "doNotSuggest": true
+}

--- a/packages/minecraftBedrock/schema/item/v1.20.10/description.json
+++ b/packages/minecraftBedrock/schema/item/v1.20.10/description.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"allOf": [
+		{
+			"$ref": "../description.json"
+		},
+		{
+			"properties": {
+				"category": {
+					"doNotSuggest": true,
+					"deprecationMessage": "Deprecated in favor of 'category' under 'minecraft:creative_category' (format_version: v1.17.20)."
+				}
+			}
+		}
+	]
+}

--- a/packages/minecraftBedrock/schema/item/v1.20.10/event.json
+++ b/packages/minecraftBedrock/schema/item/v1.20.10/event.json
@@ -1,0 +1,84 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"type": "object",
+	"allOf": [
+		{
+			"$ref": "../../event/v1.16.100/triggerItem.json"
+		},
+		{
+			"$ref": "../../event/v1.18.30/damage.json"
+		},
+		{
+			"$ref": "../../event/v1.16.200/decrementStack.json"
+		},
+		{
+			"$ref": "../../event/v1.16.100/die.json"
+		},
+		{
+			"$ref": "../../event/v1.16.100/addMobEffect.json"
+		},
+		{
+			"$ref": "../../event/v1.16.100/removeMobEffect.json"
+		},
+		{
+			"$ref": "../../event/v1.16.100/runCommand.json"
+		},
+		{
+			"$ref": "../../event/v1.16.100/shoot.json"
+		},
+		{
+			"$ref": "../../event/v1.16.100/swing.json"
+		},
+		{
+			"$ref": "../../event/v1.16.100/teleport.json"
+		},
+		{
+			"$ref": "../../event/v1.16.100/transformItem.json"
+		},
+		{
+			"properties": {
+				"randomize": {
+					"type": "array",
+					"items": {
+						"allOf": [
+							{
+								"type": "object",
+								"properties": {
+									"weight": {
+										"type": "number"
+									},
+									"condition": {
+										"type": "string",
+										"$ref": "../../molang/embedded.json"
+									}
+								}
+							},
+							{
+								"$ref": "#"
+							}
+						]
+					}
+				},
+				"sequence": {
+					"type": "array",
+					"items": {
+						"allOf": [
+							{
+								"type": "object",
+								"properties": {
+									"condition": {
+										"type": "string",
+										"$ref": "../../molang/embedded.json"
+									}
+								}
+							},
+							{
+								"$ref": "#"
+							}
+						]
+					}
+				}
+			}
+		}
+	]
+}

--- a/packages/minecraftBedrock/schema/item/v1.20.10/main.json
+++ b/packages/minecraftBedrock/schema/item/v1.20.10/main.json
@@ -1,0 +1,44 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"type": "object",
+	"properties": {
+		"minecraft:item": {
+			"required": ["description"],
+			"type": "object",
+			"properties": {
+				"description": {
+					"$ref": "./description.json"
+				},
+				"components": {
+					"allOf": [
+						{
+							"$ref": "./components/_main.json"
+						},
+						{
+							"$ref": "../dynamic/customComponents.json"
+						}
+					]
+				},
+				"events": {
+					"type": "object",
+					"allOf": [
+						{
+							"$ref": "../dynamic/currentContext/eventReferenceProperty.json"
+						},
+						{
+							"$ref": "../../project/projectPrefix.json"
+						},
+						{
+							"patternProperties": {
+								".*": {
+									"$ref": "./event.json"
+								}
+							}
+						}
+					]
+				}
+			},
+			"additionalProperties": false
+		}
+	}
+}

--- a/packages/minecraftBedrock/schema/molang/v1.19.70/queryExperimental.json
+++ b/packages/minecraftBedrock/schema/molang/v1.19.70/queryExperimental.json
@@ -2,6 +2,7 @@
 	"$schema": "http://json-schema.org/draft-07/schema",
 	"type": "string",
 	"enum": [
+		//EXPERIMENTAL. Enable 'Sniffer' to use.
 		"query.is_feeling_happy",
 		"query.is_rising",
 		"query.is_scenting",


### PR DESCRIPTION
### Items
- [ ] Released the `minecraft:shooter`, `minecraft:throwable`, `minecraft:projectile`, `minecraft:can_destroy_in_creative`, `minecraft:hover_text_color` item component out of experimental in json formats 1.20.10 and higher
- [x] Deprecate `minecraft:render_offsets` item component in json formats 1.20.10 and higher

### Script module
- [ ] Bump **`@minecraft/server`** to **`1.3.0`** stable ( **gametest-upd** branch not merged )