### PR TITLE
fix: dye powder and knockback resistance properly appear as deprecated

### DIFF
--- a/packages/minecraftBedrock/schema/item/v1.20.0/components/_main.json
+++ b/packages/minecraftBedrock/schema/item/v1.20.0/components/_main.json
@@ -34,7 +34,7 @@
 						"$ref": "../../v1.16.100/components/damage.json"
 					},
 					"minecraft:dye_powder": {
-						"$ref": "../../v1.16.100/components/dye_powder.json"
+						"$ref": "./dye_powder.json"
 					},
 					"minecraft:mirrored_art": {
 						"$ref": "../../v1.16.100/components/mirrored_art.json"
@@ -55,7 +55,7 @@
 						"$ref": "../../v1.16.100/components/block_placer.json"
 					},
 					"minecraft:knockback_resistance": {
-						"$ref": "../../v1.16.100/components/knockback_resistance.json"
+						"$ref": "./knockback_resistance.json"
 					},
 					"minecraft:enchantable": {
 						"$ref": "../../v1.16.100/components/enchantable.json"

--- a/packages/minecraftBedrock/schema/item/v1.20.0/components/dye_powder.json
+++ b/packages/minecraftBedrock/schema/item/v1.20.0/components/dye_powder.json
@@ -2,5 +2,5 @@
 	"$schema": "http://json-schema.org/draft-07/schema",
 	"additionalProperties": false,
 	"doNotSuggest": true,
-	"deprecationMessage": "Dye powder has been deprecated."
+	"deprecationMessage": "Deprecated as of v1.20.0 - Set that this item is a dye and its dye color."
 }

--- a/packages/minecraftBedrock/schema/item/v1.20.0/components/dye_powder.json
+++ b/packages/minecraftBedrock/schema/item/v1.20.0/components/dye_powder.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"additionalProperties": false,
+	"doNotSuggest": true,
+	"deprecationMessage": "Dye powder has been deprecated."
+}

--- a/packages/minecraftBedrock/schema/item/v1.20.0/components/knockback_resistance.json
+++ b/packages/minecraftBedrock/schema/item/v1.20.0/components/knockback_resistance.json
@@ -2,5 +2,5 @@
 	"$schema": "http://json-schema.org/draft-07/schema",
 	"additionalProperties": false,
 	"doNotSuggest": true,
-	"deprecationMessage": "Knockback resistance has been deprecated."
+	"deprecationMessage": "Deprecated as of v1.20.0 - For items that provide knockback resistance."
 }

--- a/packages/minecraftBedrock/schema/item/v1.20.0/components/knockback_resistance.json
+++ b/packages/minecraftBedrock/schema/item/v1.20.0/components/knockback_resistance.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"additionalProperties": false,
+	"doNotSuggest": true,
+	"deprecationMessage": "Knockback resistance has been deprecated."
+}

--- a/packages/minecraftBedrock/schema/item/v1.20.10/components/_main.json
+++ b/packages/minecraftBedrock/schema/item/v1.20.10/components/_main.json
@@ -71,6 +71,12 @@
 					},
 					"minecraft:render_offsets": {
 						"$ref": "./render_offsets.json"
+					},
+					"minecraft:knockback_resistance": {
+						"$ref": "../../v1.20.0/components/knockback_resistance.json"
+					},
+					"minecraft:dye_powder": {
+						"$ref": "../../v1.20.0/components/dye_powder.json"
 					}
 				}
 			}

--- a/packages/minecraftBedrock/schema/item/v1.20.20/components/_main.json
+++ b/packages/minecraftBedrock/schema/item/v1.20.20/components/_main.json
@@ -71,6 +71,12 @@
 					},
 					"minecraft:render_offsets": {
 						"$ref": "../../v1.20.10/components/render_offsets.json"
+					},
+					"minecraft:knockback_resistance": {
+						"$ref": "../../v1.20.0/components/knockback_resistance.json"
+					},
+					"minecraft:dye_powder": {
+						"$ref": "../../v1.20.0/components/dye_powder.json"
 					}
 				}
 			}


### PR DESCRIPTION
Previous, they were just removed, I'm not sure who did that change, but now it's corrected.