### PR TITLE
fix: collision_box warning when value is boolean

### DIFF
--- a/packages/minecraftBedrock/schema/block/v1.19.10/components/collision_box.json
+++ b/packages/minecraftBedrock/schema/block/v1.19.10/components/collision_box.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema",
 	"description": "Defines the area of the block that collides with entities. If set to true, default values are used. If set to false, the block's collision with entities is disabled. If this component is omitted, default values are used.",
-	"type": "object",
 	"title": "Collision Box",
 	"oneOf": [
 		{


### PR DESCRIPTION
![image](https://github.com/bridge-core/editor-packages/assets/83252725/b916d7d7-cb17-4e01-b3b8-6c7b62ad2bb4)
