### PR TITLE
Improve entity properties schema

### DIFF
--- a/packages/minecraftBedrock/schema/entity/v1.19.50/description.json
+++ b/packages/minecraftBedrock/schema/entity/v1.19.50/description.json
@@ -96,10 +96,6 @@
 							"title": "Type",
 							"type": "string",
 							"enum": ["int", "float", "bool", "enum"]
-						},
-						"client_sync": {
-							"title": "Client Sync",
-							"type": "boolean"
 						}
 					},
 					"oneOf": [
@@ -108,6 +104,10 @@
 							"properties": {
 								"type": {
 									"const": "bool"
+								},
+								"client_sync": {
+									"title": "Client Sync",
+									"type": "boolean"
 								},
 								"default": {
 									"title": "Default",
@@ -120,6 +120,10 @@
 							"properties": {
 								"type": {
 									"const": "int"
+								},
+								"client_sync": {
+									"title": "Client Sync",
+									"type": "boolean"
 								},
 								"default": {
 									"title": "Default",
@@ -142,6 +146,10 @@
 								"type": {
 									"const": "float"
 								},
+								"client_sync": {
+									"title": "Client Sync",
+									"type": "boolean"
+								},
 								"default": {
 									"title": "Default",
 									"type": ["number", "string"]
@@ -162,6 +170,10 @@
 							"properties": {
 								"type": {
 									"const": "enum"
+								},
+								"client_sync": {
+									"title": "Client Sync",
+									"type": "boolean"
 								},
 								"default": {
 									"title": "Default",

--- a/packages/minecraftBedrock/schema/entity/v1.19.50/description.json
+++ b/packages/minecraftBedrock/schema/entity/v1.19.50/description.json
@@ -97,29 +97,87 @@
 							"type": "string",
 							"enum": ["int", "float", "bool", "enum"]
 						},
-						"values": {
-							"title": "Values",
-							"type": "array",
-							"items": {
-								"type": ["string"]
-							}
-						},
-						"range": {
-							"title": "Range",
-							"type": "array",
-							"items": {
-								"type": ["number", "integer"]
-							}
-						},
-						"default": {
-							"title": "Default",
-							"type": ["string", "number", "boolean", "integer"]
-						},
 						"client_sync": {
 							"title": "Client Sync",
 							"type": "boolean"
 						}
-					}
+					},
+					"oneOf": [
+						{
+							"additionalProperties": false,
+							"properties": {
+								"type": {
+									"const": "bool"
+								},
+								"default": {
+									"title": "Default",
+									"type": ["boolean", "string"]
+								}
+							}
+						},
+						{
+							"additionalProperties": false,
+							"properties": {
+								"type": {
+									"const": "int"
+								},
+								"default": {
+									"title": "Default",
+									"type": ["integer", "string"]
+								},
+								"range": {
+									"title": "Range",
+									"type": "array",
+									"items": {
+										"type": "integer"
+									},
+									"minItems": 2,
+									"maxItems": 2
+								}
+							}
+						},
+						{
+							"additionalProperties": false,
+							"properties": {
+								"type": {
+									"const": "float"
+								},
+								"default": {
+									"title": "Default",
+									"type": ["number", "string"]
+								},
+								"range": {
+									"title": "Range",
+									"type": "array",
+									"items": {
+										"type": "number"
+									},
+									"minItems": 2,
+									"maxItems": 2
+								}
+							}
+						},
+						{
+							"additionalProperties": false,
+							"properties": {
+								"type": {
+									"const": "enum"
+								},
+								"default": {
+									"title": "Default",
+									"type": "string"
+								},
+								"values": {
+									"title": "Values",
+									"type": "array",
+									"items": {
+										"type": "string"
+									},
+									"minItems": 1
+								}
+							}
+						}
+					]
 				}
 			}
 		}


### PR DESCRIPTION
Improves the schema by only showing valid fields depending on the property type.

![image](https://github.com/bridge-core/editor-packages/assets/18375098/e7cb4fff-b9e1-4658-94da-c73f0592ac1f)

![image](https://github.com/bridge-core/editor-packages/assets/18375098/c0991030-0239-405d-8f78-5b2adc66e3aa)

![image](https://github.com/bridge-core/editor-packages/assets/18375098/df56a4c2-3f18-499e-87d3-37275fc98406)

It also narrows down the accepted type on the fields.

![image](https://github.com/bridge-core/editor-packages/assets/18375098/0f9f6a3f-58b5-4ef9-aeb1-af64c59e1d5f)