### PR TITLE
Bump current stable in formatVersion.json to 1.20.80

### DIFF
--- a/packages/minecraftBedrock/formatVersions.json
+++ b/packages/minecraftBedrock/formatVersions.json
@@ -1,5 +1,5 @@
 {
-	"currentStable": "1.20.60",
+	"currentStable": "1.20.80",
 	"formatVersions": [
 		"1.8.0",
 		"1.10.0",


### PR DESCRIPTION
Current stable is two versions behind which causes new projects to try and use 1.20.60 rather than 1.20.80.